### PR TITLE
Remove extraneous "https://" from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library is constructed in three main parts:
 ## Installation
 Installing directly from GitHub:
 
-    python -m pip install git+https://https://github.com/KenSciResearch/fairMLHealth
+    python -m pip install git+https://github.com/KenSciResearch/fairMLHealth
 
 Installing from a local copy of the repo:
 


### PR DESCRIPTION
There was an extra "https://" in the pip install instructions. This caused issues when I tried to install it.

Looking further, this also appears to be an issue on the github.io page which appears to be a mirror of the readme file: https://kensciresearch.github.io/fairMLHealth/